### PR TITLE
Add ease solver with cubic bezier curves

### DIFF
--- a/src/createMotion.luau
+++ b/src/createMotion.luau
@@ -5,6 +5,7 @@ local immediateSolver = require(script.Parent.solvers.immediate)
 local linearSolver = require(script.Parent.solvers.linear)
 local springSolver = require(script.Parent.solvers.spring)
 local tweenSolver = require(script.Parent.solvers.tween)
+local easeSolver = require(script.Parent.solvers.ease)
 local intermediate = require(script.Parent.utils.intermediate)
 local assign = require(script.Parent.utils.assign)
 local merge = require(script.Parent.utils.merge)
@@ -194,9 +195,13 @@ local function createMotion<T>(initialValue: T, options: types.MotionOptions?): 
 		self:to(springSolver(value :: any, params))
 	end
 
-	local function tween(self, value, params)
-		self:to(tweenSolver(value :: any, params))
-	end
+       local function tween(self, value, params)
+               self:to(tweenSolver(value :: any, params))
+       end
+
+       local function ease(self, value, params)
+               self:to(easeSolver(value :: any, params))
+       end
 
 	local function step(self, deltaTime)
 		for key, handler in motionSolvers do
@@ -289,9 +294,10 @@ local function createMotion<T>(initialValue: T, options: types.MotionOptions?): 
 		to = to,
 		immediate = immediate,
 		linear = linear,
-		spring = spring,
-		tween = tween,
-		step = step,
+               spring = spring,
+               tween = tween,
+               ease = ease,
+               step = step,
 		isComplete = isComplete,
 		onComplete = onComplete,
 		onStep = onStep,

--- a/src/curves.luau
+++ b/src/curves.luau
@@ -1,0 +1,13 @@
+--!strict
+
+return {
+    curveAccelerateMax = { 0.9, 0.1, 1, 0.2 },
+    curveAccelerateMid = { 1, 0, 1, 1 },
+    curveAccelerateMin = { 0.8, 0, 0.78, 1 },
+    curveDecelerateMax = { 0.1, 0.9, 0.2, 1 },
+    curveDecelerateMid = { 0, 0, 0, 1 },
+    curveDecelerateMin = { 0.33, 0, 0.1, 1 },
+    curveEasyEaseMax = { 0.8, 0, 0.2, 1 },
+    curveEasyEase = { 0.33, 0, 0.67, 1 },
+    curveLinear = { 0, 0, 1, 1 },
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,16 +63,38 @@ declare namespace Ripple {
 
 	function spring<T extends MotionGoal>(goal: T, options?: SpringOptions): MotionSolver<T>;
 
-	interface TweenOptions {
-		readonly time?: number;
-		readonly style?: Enum.EasingStyle;
-		readonly direction?: Enum.EasingDirection;
-		readonly repeatCount?: number;
-		readonly reverses?: boolean;
-		readonly delayTime?: number;
-	}
+        interface TweenOptions {
+                readonly time?: number;
+                readonly style?: Enum.EasingStyle;
+                readonly direction?: Enum.EasingDirection;
+                readonly repeatCount?: number;
+                readonly reverses?: boolean;
+                readonly delayTime?: number;
+        }
 
-	function tween<T extends MotionGoal>(goal: T, options?: TweenOptions): MotionSolver<T>;
+        type EasingStyle = Enum.EasingStyle | number[];
+
+        interface EaseOptions {
+                readonly duration?: number;
+                readonly easingStyle?: EasingStyle;
+        }
+
+        interface CurveTokens {
+                readonly curveAccelerateMax: string;
+                readonly curveAccelerateMid: string;
+                readonly curveAccelerateMin: string;
+                readonly curveDecelerateMax: string;
+                readonly curveDecelerateMid: string;
+                readonly curveDecelerateMin: string;
+                readonly curveEasyEaseMax: string;
+                readonly curveEasyEase: string;
+                readonly curveLinear: string;
+        }
+
+        const curves: CurveTokens;
+
+        function tween<T extends MotionGoal>(goal: T, options?: TweenOptions): MotionSolver<T>;
+        function ease<T extends MotionGoal>(goal: T, options?: EaseOptions): MotionSolver<T>;
 }
 
 declare namespace Ripple {
@@ -88,9 +110,10 @@ declare namespace Ripple {
 		to(solver: MotionSolver<T> | MapSolvers<PartialMotionGoal<T>>): void;
 		immediate(goal: PartialMotionGoal<T>): void;
 		linear(goal: PartialMotionGoal<T>, options?: LinearOptions): void;
-		spring(goal: PartialMotionGoal<T>, options?: SpringOptions): void;
-		tween(goal: PartialMotionGoal<T>, options?: TweenOptions): void;
-		step(deltaTime: number): T;
+                spring(goal: PartialMotionGoal<T>, options?: SpringOptions): void;
+                tween(goal: PartialMotionGoal<T>, options?: TweenOptions): void;
+                ease(goal: PartialMotionGoal<T>, options?: EaseOptions): void;
+                step(deltaTime: number): T;
 		isComplete(): boolean;
 		onComplete(callback: (value: T) => void): Cleanup;
 		onStep(callback: (value: T, deltaTime: number) => void): Cleanup;

--- a/src/init.luau
+++ b/src/init.luau
@@ -17,6 +17,8 @@ return {
 	config = require(script.config),
 	immediate = require(script.solvers.immediate),
 	linear = require(script.solvers.linear),
-	spring = require(script.solvers.spring),
-	tween = require(script.solvers.tween),
+       spring = require(script.solvers.spring),
+       tween = require(script.solvers.tween),
+       ease = require(script.solvers.ease),
+       curves = require(script.curves),
 }

--- a/src/solvers/ease.luau
+++ b/src/solvers/ease.luau
@@ -1,0 +1,173 @@
+--!strict
+
+local types = require(script.Parent.Parent.types)
+local intermediate = require(script.Parent.Parent.utils.intermediate)
+
+export type EasingStyle = types.EasingStyle
+export type EaseOptions = types.EaseOptions
+
+local function linear(t: number, _s: EasingStyle): number
+    return t
+end
+
+local function quad(t: number, _s: EasingStyle): number
+    return t * t
+end
+
+local function cubic(t: number, _s: EasingStyle): number
+    return t * t * t
+end
+
+local function quart(t: number, _s: EasingStyle): number
+    return t * t * t * t
+end
+
+local function quint(t: number, _s: EasingStyle): number
+    return t * t * t * t * t
+end
+
+local function exponential(t: number, _s: EasingStyle): number
+    return t == 0 and 0 or math.pow(2, 10 * (t - 1))
+end
+
+local function sine(t: number, _s: EasingStyle): number
+    return 1 - math.cos((t * math.pi) / 2)
+end
+
+local function elastic(t: number, _s: EasingStyle): number
+    return t == 0 and 0 or t == 1 and 1 or -math.pow(2, 10 * t - 10) * math.sin((t * 10 - 10.75) * ((2 * math.pi) / 3))
+end
+
+local function back(t: number, _s: EasingStyle): number
+    local c1 = 1.70158
+    local c3 = c1 + 1
+    return c3 * t * t * t - c1 * t * t
+end
+
+local function easeOutBounce(t: number): number
+    local n1 = 7.5625
+    local d1 = 2.75
+
+    if t < 1 / d1 then
+        return n1 * t * t
+    elseif t < 2 / d1 then
+        return n1 * (t - 1.5 / d1) * (t - 1.5 / d1) + 0.75
+    elseif t < 2.5 / d1 then
+        return n1 * (t - 2.25 / d1) * (t - 2.25 / d1) + 0.9375
+    else
+        return n1 * (t - 2.625 / d1) * (t - 2.625 / d1) + 0.984375
+    end
+end
+
+local function bounce(t: number, _s: EasingStyle): number
+    return 1 - easeOutBounce(1 - t)
+end
+
+local function circular(t: number, _s: EasingStyle): number
+    return -(math.sqrt(1 - t * t) - 1)
+end
+
+local function evaluateBezier(t: number, p1: number, p2: number): number
+    local oneMinusT = 1 - t
+    local oneMinusT2 = oneMinusT * oneMinusT
+    local t2 = t * t
+    return 3 * oneMinusT2 * t * p1 + 3 * oneMinusT * t2 * p2 + t * t2
+end
+
+local NUM_ITERATIONS = 10
+local function cubicBezier(t: number, values: EasingStyle): number
+    assert(typeof(values) == "table", "Expected values to be a table")
+    assert(#values == 4, "Expected values to have 4 elements")
+
+    local x1, y1, x2, y2 = table.unpack(values)
+
+    assert(x1 >= 0 and x1 <= 1, "x1 must be between 0 and 1")
+    assert(x2 >= 0 and x2 <= 1, "x2 must be between 0 and 1")
+
+    if t <= 0 then
+        return 0
+    end
+    if t >= 1 then
+        return 1
+    end
+
+    local left = 0
+    local right = 1
+    local target = t
+
+    for _ = 1, NUM_ITERATIONS do
+        local mid = (left + right) / 2
+        local x = evaluateBezier(mid, x1, x2)
+
+        if math.abs(x - target) < 0.0001 then
+            local y = evaluateBezier(mid, y1, y2)
+            return y
+        elseif x < target then
+            left = mid
+        else
+            right = mid
+        end
+    end
+
+    local finalT = (left + right) / 2
+    local y = evaluateBezier(finalT, y1, y2)
+    return y
+end
+
+local easingFunctions = {
+    [Enum.EasingStyle.Linear] = linear,
+    [Enum.EasingStyle.Quad] = quad,
+    [Enum.EasingStyle.Cubic] = cubic,
+    [Enum.EasingStyle.Quart] = quart,
+    [Enum.EasingStyle.Quint] = quint,
+    [Enum.EasingStyle.Exponential] = exponential,
+    [Enum.EasingStyle.Sine] = sine,
+    [Enum.EasingStyle.Back] = back,
+    [Enum.EasingStyle.Bounce] = bounce,
+    [Enum.EasingStyle.Elastic] = elastic,
+    [Enum.EasingStyle.Circular] = circular,
+}
+
+local function ease(motionGoal: types.MotionGoal, inputOptions: EaseOptions?): types.MotionSolver
+    local duration = if inputOptions and inputOptions.duration then inputOptions.duration else 1
+    local easingStyle = if inputOptions and inputOptions.easingStyle then inputOptions.easingStyle else Enum.EasingStyle.Linear
+    local easingFunction: (number, EasingStyle) -> number = if typeof(easingStyle) == "EnumItem" or typeof(easingStyle) == "string" then easingFunctions[easingStyle] or linear else cubicBezier
+
+    local goals = intermediate.to(motionGoal)
+
+    return function(key, state, dt)
+        local goal = intermediate.index(goals, key)
+        if goal == nil then
+            return false
+        end
+
+        local s = (state :: any)
+        local p0 = if s.initialValue ~= nil then s.initialValue else state.value or 0
+        local elapsed = (s.elapsed or 0) + dt
+
+        if s.goal and goal ~= s.goal then
+            p0 = state.value
+            elapsed = 0
+        end
+
+        local t = math.min(elapsed / duration, 1)
+        local easedT = easingFunction(t, easingStyle)
+
+        local p1 = p0 + (goal - p0) * easedT
+        local complete = elapsed >= duration or p0 == goal
+
+        if complete then
+            p1 = goal
+            p0 = goal
+            elapsed = 0
+        end
+
+        state.value = p1
+        state.complete = complete
+        s.initialValue = p0
+        s.goal = goal
+        s.elapsed = elapsed
+    end
+end
+
+return ease

--- a/src/solvers/ease.spec.luau
+++ b/src/solvers/ease.spec.luau
@@ -1,0 +1,37 @@
+return function()
+    local createMotion = require(script.Parent.Parent.createMotion)
+    local ease = require(script.Parent.ease)
+    local curves = require(script.Parent.Parent.curves)
+
+    it("should animate a value", function()
+        local motion = createMotion(0)
+
+        motion:to(ease(1, { duration = 1, easingStyle = curves.curveLinear }))
+        motion:step(0.5)
+
+        expect(math.round(motion:get()*100)/100).to.equal(0.5)
+        expect(motion:isComplete()).to.equal(false)
+
+        motion:step(0.5)
+
+        expect(motion:get()).to.equal(1)
+        expect(motion:isComplete()).to.equal(true)
+    end)
+
+    it("should animate multiple values", function()
+        local motion = createMotion({ x = 0, y = 0 })
+
+        motion:to(ease({ x = 1, y = 1 }, { duration = 1, easingStyle = curves.curveLinear }))
+        motion:step(0.5)
+
+        expect(motion:get().x).to.equal(0.5)
+        expect(motion:get().y).to.equal(0.5)
+        expect(motion:isComplete()).to.equal(false)
+
+        motion:step(0.5)
+
+        expect(motion:get().x).to.equal(1)
+        expect(motion:get().y).to.equal(1)
+        expect(motion:isComplete()).to.equal(true)
+    end)
+end

--- a/src/types.luau
+++ b/src/types.luau
@@ -28,12 +28,19 @@ export type LinearOptions = {
 } | number?
 
 export type TweenOptions = {
-	time: number?,
-	style: Enum.EasingStyle?,
-	direction: Enum.EasingDirection?,
-	repeatCount: number?,
-	reverses: boolean?,
-	delayTime: number?,
+        time: number?,
+        style: Enum.EasingStyle?,
+        direction: Enum.EasingDirection?,
+        repeatCount: number?,
+        reverses: boolean?,
+        delayTime: number?,
+}
+
+export type EasingStyle = Enum.EasingStyle | { number }
+
+export type EaseOptions = {
+       duration: number?,
+       easingStyle: EasingStyle?,
 }
 
 export type Motion<T = number> = {
@@ -49,9 +56,10 @@ export type Motion<T = number> = {
 	to: (self: Motion<T>, goal: MotionSolver | { [any]: MotionSolver }) -> (),
 	immediate: (self: Motion<T>, goal: T) -> (),
 	spring: (self: Motion<T>, goal: T, options: SpringOptions?) -> (),
-	linear: (self: Motion<T>, goal: T, options: LinearOptions?) -> (),
-	tween: (self: Motion<T>, goal: T, options: TweenOptions?) -> (),
-	step: (self: Motion<T>, deltaTime: number) -> T,
+        linear: (self: Motion<T>, goal: T, options: LinearOptions?) -> (),
+        tween: (self: Motion<T>, goal: T, options: TweenOptions?) -> (),
+       ease: (self: Motion<T>, goal: T, options: EaseOptions?) -> (),
+        step: (self: Motion<T>, deltaTime: number) -> T,
 	isComplete: (self: Motion<T>) -> boolean,
 	onComplete: (self: Motion<T>, callback: (value: T) -> ()) -> Cleanup,
 	onStep: (self: Motion<T>, callback: (value: T, deltaTime: number) -> ()) -> Cleanup,


### PR DESCRIPTION
## Summary
- add ease solver for smooth animations using cubic bezier curves
- expose curve presets and new solver via init module
- extend TypeScript and Luau types for ease options
- update createMotion to support `ease`
- provide unit tests for the new solver

## Testing
- `npm run test` *(fails: `rojo` and `run-in-roblox` not found)*
- `npm run analyze` *(fails: `curl`, `rojo`, and `luau-lsp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ceac999708329ab27fd8e71a87064